### PR TITLE
Remove transaction ID from AddTransaction.js

### DIFF
--- a/client/src/components/AddTransaction.js
+++ b/client/src/components/AddTransaction.js
@@ -11,7 +11,6 @@ export const AddTransaction = () => {
     e.preventDefault();
 
     const newTransaction = {
-      id: Math.floor(Math.random() * 100000000),
       text,
       amount: +amount
     }


### PR DESCRIPTION
As we use a transaction ID generated by MongoDB, there is no need to calculate the random ID for a new transaction